### PR TITLE
:recycle: Refactor : 슥쿡, 롱쿡 영상 업로드 시 한글 인코딩 문제

### DIFF
--- a/src/pages/LongcookUpload/index.jsx
+++ b/src/pages/LongcookUpload/index.jsx
@@ -110,7 +110,10 @@ const LongcookUpload = () => {
     });
 
     formData.append('file', file.fileObject);
-    formData.append('longcook', longcookData);
+    formData.append(
+      'longcook',
+      new Blob([longcookData], { type: 'application/json; charset=UTF-8' }),
+    );
     mutation.mutate(formData);
   };
 

--- a/src/pages/SskcookUpload/index.jsx
+++ b/src/pages/SskcookUpload/index.jsx
@@ -127,7 +127,10 @@ const SskcookUpload = () => {
     });
 
     formData.append('file', file.fileObject);
-    formData.append('sskcook', sskcookData);
+    formData.append(
+      'sskcook',
+      new Blob([sskcookData], { type: 'application/json; charset=UTF-8' }),
+    );
     mutation.mutate(formData);
   };
 


### PR DESCRIPTION
## 🚩 관련 이슈

## 📋 구현 기능 명세
- 슥쿡, 롱쿡 영상 업로드 시 한글 인코딩 문제

## 📸 결과물 스크린샷
- 업로드 요청 시 보내는 데이터 타입 지정
<img width="604" alt="image" src="https://github.com/user-attachments/assets/cd0c5f75-82a0-4d6c-a6ed-257ab2c81f21">
