### PR TITLE
🩹 Chore : live 접근 제한, event 종료, 진행 조건 수정

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -305,9 +305,13 @@ function App() {
         <Route
           path="/notice/create"
           element={
-            <CommonLayout isLogined={!!getCookie('accessToken')}>
-              <CreateNotice />
-            </CommonLayout>
+            getCookie('accessToken') && role === 'ROLE_USER' ? (
+              <CommonLayout isLogined={!!getCookie('accessToken')}>
+                <CreateNotice />
+              </CommonLayout>
+            ) : (
+              <Navigate to={'/login'} replace />
+            )
           }
         />
         <Route
@@ -321,17 +325,25 @@ function App() {
         <Route
           path="/live/class/:sessionId"
           element={
-            <CommonLayout isLogined={!!getCookie('accessToken')}>
-              <ClassSession></ClassSession>
-            </CommonLayout>
+            getCookie('accessToken') && role === 'ROLE_USER' ? (
+              <CommonLayout isLogined={!!getCookie('accessToken')}>
+                <ClassSession></ClassSession>
+              </CommonLayout>
+            ) : (
+              <Navigate to={'/login'} replace />
+            )
           }
         />
         <Route
           path="/live/:sessionId"
           element={
-            <CommonLayout isLogined={!!getCookie('accessToken')}>
-              <LiveSession></LiveSession>
-            </CommonLayout>
+            getCookie('accessToken') && role === 'ROLE_USER' ? (
+              <CommonLayout isLogined={!!getCookie('accessToken')}>
+                <LiveSession></LiveSession>
+              </CommonLayout>
+            ) : (
+              <Navigate to={'/login'} replace />
+            )
           }
         />
         <Route
@@ -357,17 +369,25 @@ function App() {
         <Route
           path="/myfridge"
           element={
-            <CommonLayout isLogined={!!getCookie('accessToken')}>
-              <Fridge />
-            </CommonLayout>
+            getCookie('accessToken') && role === 'ROLE_USER' ? (
+              <CommonLayout isLogined={!!getCookie('accessToken')}>
+                <Fridge />
+              </CommonLayout>
+            ) : (
+              <Navigate to={'/login'} replace />
+            )
           }
         />
         <Route
           path="/recommends"
           element={
-            <CommonLayout isLogined={!!getCookie('accessToken')}>
-              <RecipeRecommend />
-            </CommonLayout>
+            getCookie('accessToken') && role === 'ROLE_USER' ? (
+              <CommonLayout isLogined={!!getCookie('accessToken')}>
+                <RecipeRecommend />
+              </CommonLayout>
+            ) : (
+              <Navigate to={'/login'} replace />
+            )
           }
         />
         <Route path="/order/done" element={<OrderDone />} />

--- a/src/pages/Event/index.jsx
+++ b/src/pages/Event/index.jsx
@@ -91,7 +91,7 @@ const Event = () => {
                 />
                 <EventInfoWrapper>
                   <CustomText
-                    text={`${moment() < moment(event.enddate) ? '진행 중' : '종료'}`}
+                    text={`${moment().diff(moment(event.enddate), 'months') <= 1 ? '진행 중' : '종료'}`}
                     fontFamily={'Happiness-Sans-Bold'}
                     fontSize={'1.2rem'}
                     color={COLORS.BLACK}

--- a/src/pages/Event/styles.js
+++ b/src/pages/Event/styles.js
@@ -42,6 +42,7 @@ export const EventInfoWrapper = styled.div`
   display: flex;
   flex-direction: column;
   gap: 0.8vh;
+  line-height: 2vh;
   // border: 10px solid BLACK;
 `;
 

--- a/src/pages/EventDetail/index.jsx
+++ b/src/pages/EventDetail/index.jsx
@@ -114,7 +114,9 @@ const EventDetail = () => {
               color={COLORS.BLACK}
             />
           </EventInfoContainer>
-          {moment() < moment(eventDetail?.enddate) ? (
+          {moment().diff(moment(eventDetail?.enddate), 'months') <= 1 ? (
+            '진행 중'
+          ) : '종료' ? (
             <CustomText
               text={`진행 중`}
               fontFamily={'Happiness-Sans-Bold'}
@@ -153,12 +155,13 @@ const EventDetail = () => {
           fontSize={'1rem'}
           color={COLORS.BLACK}
         />
-        {moment() < moment(eventDetail?.enddate) && (
+        {moment().diff(moment(eventDetail?.enddate), 'months') <= 1 && (
           <CustomButton
             text={'알림 받기'}
+            fontSize={'1rem'}
             color={COLORS.WHITE}
-            width={'12vw'}
-            height={'6vh'}
+            width={'10vw'}
+            height={'5vh'}
             backgroundColor={COLORS.ORANGE}
             borderColor={COLORS.ORANGE}
             borderRadius={'40px'}


### PR DESCRIPTION
## 🚩 관련 이슈

## 📋 구현 기능 명세
- 라이브 참가는 로그인 후에만 가능하도록
- event 흐름
e.g.) 1월에 인기있었던 10개의 레시피에 대해서 2월 1일 공지.
7일까지 사전 신청.
남은 한달동안 한정 판매.

## 📸 결과물 스크린샷

